### PR TITLE
EM update

### DIFF
--- a/SAXS_EM/SAXS_EM.html
+++ b/SAXS_EM/SAXS_EM.html
@@ -223,16 +223,18 @@ In this tutorial you will learn how to use the EM validation program of the AUSA
 	</ul>
 
 <h4>Challenges</h4>
-	As a practical example of how this program can be used, download the following three files. 
-	For the last two links, you will need to click the "Download raw file" button in the top right corner, underneath the "History" icon.
-	<ul>
-		<li><a href="https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-12747/map/emd_12747.map.gz" target="_blank">EMD-12747</a></li>
-		<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_2020_Q4.ccp4" target="_blank">Harwood (hosted with permission)</a></li>
-		<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_native.dat" target="_blank">SAXS data (hosted with permission)</a></li>
-	</ul>
-	The first two files are, respectively, a cryo-EM and negative-stain EM map of the same protein, but with different conformations. You can plot them in e.g. PyMOL to see the differences. 
-	The third file is in-house SAXS data measured for the same protein. 
-	Use the SAXS data to validate both maps, and compare the results. Which conformation does the SAXS data support?
+	<p>
+		As a practical example of how this program can be used, download the following three files. 
+		For the last two links, you will need to click the "Download raw file" button in the top right corner, underneath the "History" icon.
+		<ul>
+			<li><a href="https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-12747/map/emd_12747.map.gz" target="_blank">EMD-12747</a></li>
+			<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_2020_Q4.ccp4" target="_blank">Harwood (hosted with permission)</a></li>
+			<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_native.dat" target="_blank">SAXS data (hosted with permission)</a></li>
+		</ul>
+		The first two files are, respectively, a cryo-EM and negative-stain EM map of the same protein, but with different conformations. You can plot them in e.g. PyMOL to see the differences. 
+		The third file is in-house SAXS data measured for the same protein. 
+		Use the SAXS data to validate both maps, and compare the results. Which conformation does the SAXS data support?
+	</p>
 
 <!--
 DO NOT CHANGE ANYTHING BELOW

--- a/SAXS_EM/SAXS_EM.html
+++ b/SAXS_EM/SAXS_EM.html
@@ -231,8 +231,8 @@ In this tutorial you will learn how to use the EM validation program of the AUSA
 			<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_2020_Q4.ccp4" target="_blank">Harwood (hosted with permission)</a></li>
 			<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_native.dat" target="_blank">SAXS data (hosted with permission)</a></li>
 		</ul>
-		The first two files are, respectively, a cryo-EM and negative-stain EM map of the same protein, but with different conformations. You can plot them in e.g. PyMOL to see the differences. 
-		The third file is in-house SAXS data measured for the same protein. 
+		Recently, there has been some controversy regarding the structure of the A2M protein, with two different groups finding different conformations of the protein using cryo-EM (emd_12747.map) and negative-stain EM (A2M_2020_Q4.ccp4).
+		The SAXS data measured by the second group (A2M_native.dat) has also been provided. 
 		Use the SAXS data to validate both maps, and compare the results. Which conformation does the SAXS data support?
 	</p>
 


### PR DESCRIPTION
I've implemented the last comments for the EM validation tutorial. 

1. Added a small gap above "Feedback"

2. Added supplementary background information on the challenge data. Here's the new description for convenience:

> Recently, there has been some controversy regarding the structure of the A2M protein, with two different groups finding different conformations of the protein using cryo-EM (emd_12747.map) and negative-stain EM (A2M_2020_Q4.ccp4). The SAXS data measured by the second group (A2M_native.dat) has also been provided. Use the SAXS data to validate both maps, and compare the results. Which conformation does the SAXS data support?

Should I add references to the discussion? I'm not sure if it's a good idea to "expose" it like this. 

3. I did _not_ move the two datasets from my repository here, for two reasons:  
* The data is quite large (11MB), so I'm not sure if that's something we want to include and carry around in the main branch here. 
* Should we create a new "data" branch or something similar, the user experience will be exactly the same: manually going to a GitHub repo and downloading the raw data. I tried looking up how to automatically start the download when clicking the link, but it does not seem like GitHub supports this. 