### PR TITLE
Add missing refs in EM tutorial

### DIFF
--- a/SAXS_EM/SAXS_EM.html
+++ b/SAXS_EM/SAXS_EM.html
@@ -231,7 +231,8 @@ In this tutorial you will learn how to use the EM validation program of the AUSA
 			<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_2020_Q4.ccp4" target="_blank">Harwood (hosted with permission)</a></li>
 			<li><a href="https://github.com/AUSAXS/AUSAXS/blob/master/tests/files/A2M_native.dat" target="_blank">SAXS data (hosted with permission)</a></li>
 		</ul>
-		Recently, there has been some controversy regarding the structure of the A2M protein, with two different groups finding different conformations of the protein using cryo-EM (emd_12747.map) and negative-stain EM (A2M_2020_Q4.ccp4).
+		Recently, there has been some controversy regarding the structure of the A2M protein, with two different groups finding different conformations of the protein using cryo-EM (emd_12747.map) and negative-stain EM (A2M_2020_Q4.ccp4)
+		[<a href="https://doi.org/10.1016/j.mcpro.2021.100090" target="_blank">1</a>, <a href="https://doi.org/10.1073/pnas.2200102119" target="_blank">2</a>, <a href="https://doi.org/10.1073/pnas.2210218119" target="_blank">3</a>, <a href="https://doi.org/10.1073/pnas.2211048119" target="_blank">4</a>].
 		The SAXS data measured by the second group (A2M_native.dat) has also been provided. 
 		Use the SAXS data to validate both maps, and compare the results. Which conformation does the SAXS data support?
 	</p>


### PR DESCRIPTION
This PR adds four missing references to the arguments in the literature regarding the shape of A2M, as used and discussed in the tutorial.  